### PR TITLE
Add Plausible.io analytics tracking to website

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;800&family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <meta name="theme-color" content="#0b1220" />
     <title>SolAI Systems</title>
+    <script defer data-domain="solai-systems.com" data-spa="auto" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js"></script>
+    <script>
+      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+    </script>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -5,12 +5,24 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;800&family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;600;700;800&family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
     <meta name="theme-color" content="#0b1220" />
     <title>SolAI Systems</title>
-    <script defer data-domain="solai-systems.com" data-spa="auto" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js"></script>
+    <script
+      defer
+      data-domain="solai-systems.com"
+      data-spa="auto"
+      src="https://plausible.io/js/script.file-downloads.hash.outbound-links.pageview-props.revenue.tagged-events.js"
+    ></script>
     <script>
-      window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }
+      window.plausible =
+        window.plausible ||
+        function () {
+          (window.plausible.q = window.plausible.q || []).push(arguments);
+        };
     </script>
   </head>
 


### PR DESCRIPTION
## Purpose
The user requested to integrate Plausible.io as a traffic tracking and monitoring tool for their website (solai-systems.com). They provided the specific installation snippet from Plausible.io that needed to be added to the site's head section to enable comprehensive analytics tracking including file downloads, hash changes, outbound links, pageview properties, revenue tracking, and tagged events.

## Code changes
- Added Plausible.io analytics script to the `<head>` section of index.html
- Included the main tracking script with data-domain set to "solai-systems.com" and data-spa="auto" for single-page application support
- Added the Plausible helper function to enable programmatic event tracking
- Reformatted existing Google Fonts link for better readability (no functional change)

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 9`

🔗 [Edit in Builder.io](https://builder.io/app/projects/db8b6d31d9d14889b1fcad7dfed7de9e/spark-garden)

👀 [Preview Link](https://db8b6d31d9d14889b1fcad7dfed7de9e-spark-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>db8b6d31d9d14889b1fcad7dfed7de9e</projectId>-->
<!--<branchName>spark-garden</branchName>-->